### PR TITLE
Prevent default event action on NotesCard click.

### DIFF
--- a/src/routes/explore.jsx
+++ b/src/routes/explore.jsx
@@ -137,7 +137,9 @@ export default function ExploreRoute() {
                                 <NotesCard
                                     key={note.id}
                                     note={note}
-                                    onClick={() => {
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        e.stopPropagation();
                                         handleNoteClick(note)
                                     }}
                                 />

--- a/src/routes/notesList.jsx
+++ b/src/routes/notesList.jsx
@@ -265,7 +265,9 @@ export default function NotesList() {
                                 <NotesCard
                                     key={note.id}
                                     note={note}
-                                    onClick={() => {
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        e.stopPropagation();
                                         handleNoteClick(note)
                                     }}
                                     onEdit={memoizedHandleEditNote}


### PR DESCRIPTION
Add e.preventDefault() and e.stopPropagation() to onClick handlers in NotesCard components within explore.jsx and notesList.jsx. This change prevents default event actions and propagation when a note card is clicked, ensuring only the handleNoteClick function is executed.
