### PR TITLE
Refactor prop names for SendResetEmailDialog component

### DIFF
--- a/src/components/loginForm.jsx
+++ b/src/components/loginForm.jsx
@@ -262,9 +262,9 @@ export function LoginForm({
 
                 </Layout>
             </GoogleOAuthProvider>
-            <SendResetEmailDialog setOpenResetDialog={setOpenResetDialog}
-                                  openResetDialog={openResetDialog}
-                                  user={user}
+            <SendResetEmailDialog user={user}
+                                  open={openResetDialog}
+                                  setOpen={setOpenResetDialog}
                                   sendEmail={(email) => sendEmail(email)}/>
         </>
     )


### PR DESCRIPTION
Renamed props in SendResetEmailDialog to align with a clearer and more consistent naming convention. This change improves code readability and reduces potential confusion when managing dialog states.
